### PR TITLE
Ft Profile Information from Travel Request Page #181414624

### DIFF
--- a/public/api-docs/trips.yaml
+++ b/public/api-docs/trips.yaml
@@ -25,6 +25,9 @@ definitions:        # Schema defination for request body
         type: string
       travelReason:
         type: string
+      saveInfo:
+        type: boolean
+        default: false
   ApproveOrRejectRequests:
     type: object
     required: 
@@ -211,3 +214,16 @@ paths:
           description: data not found
         '500':
           description: Server Error
+  /api/v1/trip/profile/info:  
+    get:                 
+      tags:              
+        - Trip      
+      summary: Get Trip Request Profile Information 
+      operationId: getTripInfo    
+      responses:
+        '200':
+          description: Fetched successfully
+        '500':
+          description: Internal server error
+        '404':
+          description: Not Found

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -4,5 +4,11 @@
 import * as userController from './userController';
 import * as tripController from './trip.controller';
 import * as tripStatController from './tripStatistics.controller';
+import * as tripProfileController from './tripProfileController';
 
-export { tripController, userController, tripStatController };
+export {
+  tripController,
+  userController,
+  tripStatController,
+  tripProfileController
+};

--- a/src/controllers/trip.controller.js
+++ b/src/controllers/trip.controller.js
@@ -8,6 +8,7 @@ import {
   createdResponse,
   confictResponse
 } from '../utils/responseHandler';
+import { addProfileInfo } from './tripProfileController';
 
 export const makeTripRequest = async (req, res) => {
   const {
@@ -32,10 +33,12 @@ export const makeTripRequest = async (req, res) => {
   );
   if (badRequest) return ApplicationError.badRequestError(badRequest, res);
   if (trip) {
-    createdResponse(res, 'New trip request made successfully', trip);
-  } else {
-    ApplicationError.internalServerError(error, res);
+    return (
+      (await addProfileInfo(trip, req, res)) ||
+      createdResponse(res, 'New trip request made successfully', trip)
+    );
   }
+  ApplicationError.internalServerError(error, res);
 };
 
 export const getAllTripRequest = async (req, res) => {

--- a/src/controllers/tripProfileController.js
+++ b/src/controllers/tripProfileController.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable import/prefer-default-export */
+import * as ApplicationError from '../utils/errors/applicationsErrors';
+import {
+  createdResponse,
+  notFoundResponse,
+  successResponse
+} from '../utils/responseHandler';
+import {
+  fetchTripProfile,
+  findOneTripInfo,
+  isSavingTripInfo
+} from '../services/tripProfileInfo';
+
+export const addProfileInfo = async (trip, req, res) => {
+  const tripProfile = await isSavingTripInfo(trip, req);
+  if (tripProfile && tripProfile.dataValues) {
+    return createdResponse(
+      res,
+      'New trip request made successfully and info saved',
+      trip
+    );
+  }
+  if (tripProfile && tripProfile.updated) {
+    return createdResponse(
+      res,
+      'New trip request made successfully and info updated',
+      trip
+    );
+  }
+  if (!tripProfile) return false;
+};
+
+export const getTripProfileInfo = async (req, res) => {
+  try {
+    if ((await findOneTripInfo(req.user.id)) === null) {
+      notFoundResponse(res, 'Trip Profile Not Found');
+    }
+    const profile = await fetchTripProfile(req.user.id);
+    return profile.error
+      ? ApplicationError.validationError(profile.error, res)
+      : successResponse(res, 200, 'Profile fetched successfully', profile);
+  } catch (error) {
+    ApplicationError.internalServerError(error, res);
+  }
+};

--- a/src/database/migrations/20220427061915-create-trip-profile-info.js
+++ b/src/database/migrations/20220427061915-create-trip-profile-info.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable require-jsdoc */
+
+export async function up(queryInterface, DataTypes) {
+  await queryInterface.createTable('tripProfileInfos', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      allowNull: false,
+      primaryKey: true
+    },
+    userId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      isUUID: 4,
+      references: {
+        model: 'users',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    tripId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      isUUID: 4,
+      references: {
+        model: 'trips',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    createdAt: {
+      allowNull: false,
+      type: DataTypes.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: DataTypes.DATE
+    }
+  });
+}
+export async function down(queryInterface, Sequelize) {
+  await queryInterface.dropTable('tripProfileInfos');
+}

--- a/src/database/models/tripprofileinfo.js
+++ b/src/database/models/tripprofileinfo.js
@@ -1,0 +1,60 @@
+/* eslint-disable require-jsdoc */
+/* eslint-disable no-unused-vars */
+
+import { Model } from 'sequelize';
+
+export default (sequelize, DataTypes) => {
+  class TripProfileInfo extends Model {
+    static associate(models) {
+      models.Users.hasMany(TripProfileInfo, {
+        foreignKey: 'userId',
+        onDelete: 'CASCADE'
+      });
+      TripProfileInfo.belongsTo(models.Users, {
+        foreignKey: 'userId'
+      });
+
+      models.Trips.hasMany(TripProfileInfo, {
+        foreignKey: 'tripId',
+        onDelete: 'CASCADE'
+      });
+      TripProfileInfo.belongsTo(models.Trips, {
+        foreignKey: 'tripId'
+      });
+    }
+  }
+
+  TripProfileInfo.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      userId: {
+        type: DataTypes.UUID,
+        allowNull: false
+      },
+      tripId: {
+        type: DataTypes.UUID,
+        allowNull: false
+      },
+      createdAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      }
+    },
+    {
+      sequelize,
+      modelName: 'TripProfileInfo',
+      tableName: 'tripProfileInfos',
+      timestamps: true
+    }
+  );
+  return TripProfileInfo;
+};

--- a/src/routes/trip.route.js
+++ b/src/routes/trip.route.js
@@ -1,6 +1,10 @@
 /* eslint-disable import/named */
 import express from 'express';
-import { tripController, tripStatController } from '../controllers';
+import {
+  tripController,
+  tripStatController,
+  tripProfileController
+} from '../controllers';
 import { validate, errorHandler, isLoggedIn } from '../middlewares';
 import * as auth from '../middlewares/authorize';
 import {
@@ -38,6 +42,12 @@ tripRouter.get(
   '/:id',
   isLoggedIn,
   errorHandler(tripController.getOneTripRequest)
+);
+
+tripRouter.get(
+  '/profile/info',
+  isLoggedIn,
+  errorHandler(tripProfileController.getTripProfileInfo)
 );
 
 tripRouter.delete(

--- a/src/services/tripProfileInfo.js
+++ b/src/services/tripProfileInfo.js
@@ -1,0 +1,74 @@
+import models from '../database/models';
+
+const { TripProfileInfo } = models;
+
+const createTripProfile = async (userId, tripId) => {
+  try {
+    const tripInfo = await TripProfileInfo.create({
+      userId,
+      tripId
+    });
+    return tripInfo;
+  } catch (error) {
+    return { error };
+  }
+};
+
+const fetchTripProfile = async (userId) => {
+  const getRecord = await TripProfileInfo.findOne({
+    where: { userId },
+    include: [
+      {
+        model: models.Users,
+        attributes: ['firstname', 'lastname']
+      },
+      {
+        model: models.Trips,
+        attributes: { exclude: ['userId'] }
+      }
+    ],
+    attributes: ['id']
+  });
+
+  return getRecord;
+};
+
+const findOneTripInfo = async (userId) => {
+  try {
+    const tripInfo = await TripProfileInfo.findOne({
+      where: { userId }
+    });
+    return tripInfo;
+  } catch (error) {
+    return { error };
+  }
+};
+
+const updateTripProfileInfo = async (userId, newValue) => {
+  try {
+    await TripProfileInfo.update(newValue, {
+      where: {
+        userId
+      }
+    });
+    return { updated: true };
+  } catch (error) {
+    return { error };
+  }
+};
+
+const isSavingTripInfo = async (trip, req) => {
+  if (!req.body.saveInfo) return false;
+  const profileInfo = await findOneTripInfo(req.user.id);
+  return profileInfo && profileInfo.dataValues
+    ? updateTripProfileInfo(req.user.id, { tripId: trip.dataValues.id })
+    : createTripProfile(req.user.id, trip.dataValues.id);
+};
+
+export {
+  fetchTripProfile,
+  createTripProfile,
+  findOneTripInfo,
+  isSavingTripInfo,
+  updateTripProfileInfo
+};

--- a/src/validations/tripValidation.js
+++ b/src/validations/tripValidation.js
@@ -33,7 +33,10 @@ const tripSchema = Joi.object().keys({
       'date.greater': `"Date of return" should be greater than "Date of travel"`
     }),
   travelReason: Joi.string().min(5).required().label('Reason for travel'),
-  accomodationId: Joi.number().required().label('Accomodation')
+  accomodationId: Joi.number().required().label('Accomodation'),
+  saveInfo: Joi.boolean()
+    .default(false)
+    .messages({ boolean: 'saveInfo must be boolean' })
 });
 
 export const validateDestination = async (trip) => {

--- a/test/tripProfileInfo.spec.js
+++ b/test/tripProfileInfo.spec.js
@@ -1,0 +1,130 @@
+import chai, { expect, request, use } from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../src/app';
+import models from '../src/database/models';
+
+const { TripProfileInfo, Users } = models;
+chai.should();
+use(chaiHttp);
+
+let loginToken,
+  today = new Date();
+
+const tripProfileInfo = {
+  departure: 'Huye',
+  destination: 'Kayonza',
+  dateOfTravel: today.setDate(new Date().getDate() + 1),
+  dateOfReturn: today.setDate(new Date().getDate() + 2),
+  accomodationId: 2,
+  travelReason: 'This is travel reason in test',
+  saveInfo: false
+};
+const tripProfileInfo2 = {
+  departure: 'Huye',
+  destination: 'Kayonza',
+  dateOfTravel: today.setDate(new Date().getDate() + 1),
+  dateOfReturn: today.setDate(new Date().getDate() + 2),
+  accomodationId: 2,
+  travelReason: 'This is travel reason in test',
+  saveInfo: true
+};
+
+before(async () => {
+  const res = await request(server).post('/api/user/login').send({
+    email: 'demouser2@cod.be',
+    password: 'altp6@random'
+  });
+  loginToken = res.body.accessToken;
+});
+
+describe('Profile Information From Trip Request', () => {
+  describe('/POST api/v1/trip/', () => {
+    it('Should validate saveInfo from req.body', async () => {
+      const requester = request(server).keepOpen();
+      tripProfileInfo.saveInfo = '';
+      tripProfileInfo2.saveInfo = 2;
+      const [badReq, badReq2] = await Promise.all([
+        requester
+          .post('/api/v1/trip')
+          .set('Authorization', `Bearer ${loginToken}`)
+          .send(tripProfileInfo),
+        requester
+          .post('/api/v1/trip')
+          .set('Authorization', `Bearer ${loginToken}`)
+          .send(tripProfileInfo2)
+      ]);
+      expect(badReq).to.have.status(400);
+      expect(badReq.body).to.have.property('data');
+      expect(badReq.body.data)
+        .to.have.property('message')
+        .and.to.be.eql('saveInfo must be a boolean');
+
+      expect(badReq2).to.have.status(400);
+      expect(badReq2.body).to.have.property('data');
+      expect(badReq2.body.data)
+        .to.have.property('message')
+        .and.to.be.eql('saveInfo must be a boolean');
+    });
+
+    it('Should Not Save Profile Info If Checkbox Is Unchecked', async () => {
+      tripProfileInfo.saveInfo = false;
+      const res = await chai
+        .request(server)
+        .post('/api/v1/trip')
+        .set('Authorization', `Bearer ${loginToken}`)
+        .send(tripProfileInfo);
+      expect(res).to.have.status(201);
+      expect(res.body).to.have.property('data');
+      expect(res.body.data)
+        .to.have.property('message')
+        .and.to.be.eql('New trip request made successfully');
+    });
+  });
+
+  it('Should Save Profile Info From Trip Req.', async () => {
+    const requester = request(server).keepOpen();
+    tripProfileInfo.saveInfo = true;
+    const [req] = await Promise.all([
+      requester
+        .post('/api/v1/trip')
+        .set('Authorization', `Bearer ${loginToken}`)
+        .send(tripProfileInfo)
+    ]);
+    expect(req).to.have.status(201);
+    expect(req.body).to.have.property('data');
+    expect(req.body.data)
+      .to.have.property('message')
+      .and.to.be.eql('New trip request made successfully and info saved');
+  });
+
+  it('Should Update Profile Info If Exist', async () => {
+    const requester = request(server).keepOpen();
+    tripProfileInfo.saveInfo = true;
+    const [req] = await Promise.all([
+      requester
+        .post('/api/v1/trip')
+        .set('Authorization', `Bearer ${loginToken}`)
+        .send(tripProfileInfo)
+    ]);
+    expect(req).to.have.status(201);
+    expect(req.body).to.have.property('data');
+    expect(req.body.data)
+      .to.have.property('message')
+      .and.to.be.eql('New trip request made successfully and info updated');
+  });
+
+  describe('/GET api/v1/trip/profile/info', () => {
+    it('Should get tripProfileInfo of user', async () => {
+      const requester = request(server).keepOpen();
+      const [req] = await Promise.all([
+        requester
+          .get('/api/v1/trip/profile/info')
+          .set('Authorization', `Bearer ${loginToken}`)
+      ]);
+      expect(req).to.have.status(200);
+      expect(req.body).to.have.property('data');
+      expect(req.body.data.message).to.be.eql('Profile fetched successfully');
+      expect(req.body.data).to.have.property('data').and.to.be.an('object');
+    });
+  });
+});


### PR DESCRIPTION
<!-- Change the "53" to your pull request number -->

![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/sergenm/fc852272be18bb21d4a7418ab58e2edc/raw/cod-be__pull_71.json)

### 1. Name of task
- Name Of The Assigned Task
### 2. Pivot Tracker ID
- [#181414624](https://www.pivotaltracker.com/story/show/181414624)
### 3. PR
- #71 
### 4. Description of task
- The user's personal information is grouped such that if the user activates the checkbox to remember all the personal details entered, such details are presented in a non-editable form on the next travel request initiation screen
- For users who do not click on the checkbox, there is a fresh opportunity to provide personal details at every travel request initiation
### 5. Endpoints 
- POST - api/v1/trip?saveInfo=true
- GET - api/v1/trip/profileInfo
