### PR TITLE
Ft mark all notifications as read #181414622

### DIFF
--- a/public/api-docs/notifications.yaml
+++ b/public/api-docs/notifications.yaml
@@ -70,3 +70,34 @@ paths:
           description: Not Found
         '401':
           description: Unauthenticated               
+  /api/v1/read/notification/{Id}:           
+    post:                 
+      tags:              
+        - Notifications        
+      summary: Marking notification as read
+      parameters:
+        - in: path
+          name: Id
+          schema:
+            type: string
+          required: true
+          description: Notification id
+      responses:          
+        '200':
+          description: Marked notification succesfully
+        '404':
+          description: Notification not found
+        '500':
+          description: internal server error
+  /api/v1/read/notifications:           
+    post:                 
+      tags:               
+        - Notifications         
+      summary: Marking all notification as read
+      responses:         
+        '200':
+          description: Marked all notification successfully
+        '404':
+          description: No notifications found
+        '500':
+          description: internal server error

--- a/src/controllers/tripStatistics.controller.js
+++ b/src/controllers/tripStatistics.controller.js
@@ -5,9 +5,10 @@ import { getUserRole } from '../services/rolesService';
 
 export const tripStatistics = async (req, res) => {
   const userId = req.user.id;
-  const { start } = req.query;
+  let { start } = req.query;
   let { end } = req.query;
-  const endingDate = end;
+  const startString = start;
+  const endString = end;
   const isToday =
     new Date(end).toLocaleDateString() === new Date().toLocaleDateString();
   if (isToday) {
@@ -16,7 +17,7 @@ export const tripStatistics = async (req, res) => {
     end = new Date(end);
     end.setDate(end.getDate() + 1);
   }
-
+  start = new Date(start);
   const userRole = await getUserRole(userId);
   if (userRole !== 'Requester' && userRole !== 'Manager') {
     return ApplicationError.AuthorizationError(
@@ -29,7 +30,7 @@ export const tripStatistics = async (req, res) => {
     return successResponse(
       res,
       200,
-      `You succesfully got all trips you have made between ${start} and ${endingDate} succesfully`,
+      `You succesfully got all trips you have made between ${startString} and ${endString} succesfully`,
       { trips: trips.count }
     );
   }

--- a/src/routes/notifications.js
+++ b/src/routes/notifications.js
@@ -2,7 +2,9 @@ import express from 'express';
 import {
   addNoficationStatus,
   getNotifications,
-  getNotificationById
+  getNotificationById,
+  readAllNotifications,
+  readNotification
 } from '../controllers/notificationsController';
 import { validate, isLoggedIn, paramsValidate } from '../middlewares';
 import { validateType, validateParameter } from '../validations/notifications';
@@ -21,6 +23,18 @@ notificationsRouter.get(
   isLoggedIn,
   paramsValidate(validateParameter),
   getNotificationById
+);
+notificationsRouter.post(
+  '/v1/read/notification/:Id',
+  isLoggedIn,
+  paramsValidate(validateParameter),
+  readNotification
+);
+
+notificationsRouter.post(
+  '/v1/read/notifications',
+  isLoggedIn,
+  readAllNotifications
 );
 
 export default notificationsRouter;

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -43,12 +43,16 @@ const checkIfBlocked = async (where) => {
   }
   return true;
 };
-
+const markNotification = async (notification) => {
+  notification.isRead = true;
+  await notification.save();
+};
 export {
   addTripStatusNotification,
   addTripCommentNotification,
   addNotificationsStatus,
   allNotifications,
   checkIfBlocked,
-  getById
+  getById,
+  markNotification
 };

--- a/src/validations/notifications.js
+++ b/src/validations/notifications.js
@@ -15,7 +15,7 @@ const validateType = Joi.object().keys({
     .messages({ Type: 'Give a valid notification status(true or false)' })
 });
 const validateParameter = Joi.object().keys({
-  Id: Joi.string().min(4).label('Id').messages({
+  Id: Joi.string().guid().min(4).label('Id').messages({
     Type: 'Give a valid notification Id)'
   })
 });

--- a/test/userNotification.spec.js
+++ b/test/userNotification.spec.js
@@ -189,5 +189,43 @@ describe('Manage user notifications', () => {
       expect(res).to.have.status(200);
       expect(res.body.data).to.have.property('data');
     });
+    it('The user logged in can mark notification as read', async () => {
+      const res2 = await chai
+        .request(app)
+        .post(`/api/v1/read/notification/${notificationId}`)
+        .set({ Authorization: `Bearer ${loginToken}` });
+      expect(res2).to.have.property('status', 200);
+      expect(res2.body.data).to.have.property(
+        'message',
+        `Notification marked as read succesfully`
+      );
+    });
+    it('The Notification read can not be read again', async () => {
+      const res2 = await chai
+        .request(app)
+        .post(`/api/v1/read/notification/${notificationId}`)
+        .set({ Authorization: `Bearer ${loginToken}` });
+      expect(res2).to.have.property('status', 200);
+      expect(res2.body.data).to.have.property(
+        'message',
+        `The notification is already read`
+      );
+    });
+    it('If notification does not exist user can not read it', async () => {
+      const res2 = await chai
+        .request(app)
+        .post(`/api/v1/read/notification/0c58cb56-40f7-4e5b-905e-b7a915604253`)
+        .set({ Authorization: `Bearer ${loginToken}` });
+      expect(res2).to.have.property('status', 404);
+      expect(res2.body).to.have.property('Error', `Notification not found`);
+    });
+    it('If user has no notification can not mark them', async () => {
+      const res2 = await chai
+        .request(app)
+        .post(`/api/v1/read/notifications`)
+        .set({ Authorization: `Bearer ${loginToken}` });
+      expect(res2).to.have.property('status', 404);
+      expect(res2.body).to.have.property('Error', `You have no notification`);
+    });
   });
 });


### PR DESCRIPTION
<!-- Change the "53" to your pull request number -->

![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/sergenm/fc852272be18bb21d4a7418ab58e2edc/raw/cod-be__pull_74.json)

### 1. Name of task
- Users should be able to mark all notifications as read
### 2. Pivot Tracker ID
- #181414622
### 3. Pivot Tracker Link
[-](https://www.pivotaltracker.com/story/show/181414622)
### 4. Branch Name
- ft-mark-all-notifications-as-read-#181414622
### 5. Description of task
**Why**
Users may want to tidy up their notification panel

As user, I should be able to mark all my notifications as read
So that, I can keep my notifications panel clean

**Acceptance Criteria**
-Given that the user is logged in, then when the user clicks on ‘Mark all as read’ the notification icon count should change to the bell component with no number attached to it
-Given that the user is logged in, then when the user clicks on ‘one notification’ the notification icon count should decrement by one if the notification hadn't been read before

### 7. Logic on the task to be completed
To mark a notification as read or as unread will be implemented by finding the user must give the notificationId and the system search the notification based on both notificationId and userId. The userId will be from token. so that we be sure that the owner of the user will mark his notification. The user can mark all notification as read by finding the list of notification and then mark them as read or unread
### 8. Logic On Actual Implementation
To mark notification will be by setting isRead proerty to true or false to the notification by the owner of the notification. Then to mark all notification as read will be implemented by setting isRead property of notification.
### 9. Endpoints 
- POST /api/v1/notification/:notificationId/read
- POST /api//v1/notification/read'
